### PR TITLE
KCL-10599 - More robust reconciliation of the leaf text nodes if ther…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kontent-ai/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.7-internal.2",
+  "version": "0.11.7-internal.3",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/selection/findAncestorWithOffsetKey.js
+++ b/src/component/selection/findAncestorWithOffsetKey.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @emails oncall+draft_js
+ */
+
+'use strict';
+
+const getCorrectDocumentFromNode = require('getCorrectDocumentFromNode');
+const getOffsetKeyFromNode = require('getOffsetKeyFromNode');
+
+/**
+ * Gets the nearest ancestor with offset key.
+ */
+function findAncestorWithOffsetKey(node: Node): ?Node {
+  let searchNode = node;
+  while (
+    searchNode &&
+    searchNode !== getCorrectDocumentFromNode(node).documentElement
+  ) {
+    const key = getOffsetKeyFromNode(searchNode);
+    if (key != null) {
+      return searchNode;
+    }
+    searchNode = searchNode.parentNode;
+  }
+  return null;
+}
+
+module.exports = findAncestorWithOffsetKey;

--- a/src/component/selection/getOffsetKeyFromNode.js
+++ b/src/component/selection/getOffsetKeyFromNode.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ * @emails oncall+draft_js
+ */
+
+'use strict';
+
+/**
+ * Get offset key from a node.
+ */
+const isElement = require('isElement');
+
+function getOffsetKeyFromNode(node: Node): ?string {
+  if (isElement(node)) {
+    const castedNode: Element = (node: any);
+    const offsetKey = castedNode.getAttribute('data-offset-key');
+    if (offsetKey) {
+      return offsetKey;
+    }
+  }
+  return null;
+}
+
+module.exports = getOffsetKeyFromNode;


### PR DESCRIPTION
### Problematic scenarios / How to reproduce

It can be reproduced either in our simple text element or in examples/draft-0-10-0/customStyles/customStyles.html in DraftJS repo. Also on [draftjs.org](http://draftjs.org/) 

When there is a tab in the node text, then when you enter a new char to it, the Chrome browser splits the span with data-text node into two (while keeping the attribute in both) and inserts one extra anonymous text node between them, it produces the following HTML based on where you place the new char

`<span data-text="true">hello</span>X<span data-text="true">\tworld</span>`

`<span data-text="true">hello\t</span>X<span data-text="true">world</span>`

`<span data-text="true">hello\tworld</span>X`

Note: While this happens at the very end of the text node, it doesn’t at the very start of the text node, that’s why above are only 3 examples

Note2: There was existing code in editOnInput handling similar situation when typing at the start of the line but it seems not reproducible anymore (or we don’t know how)

It was very single-case based and not robust at all (that’s why it couldn’t handle the more complicated cases such as the one with the tab)

I left the comment in there and the new code should handle this case as well, should it ever occur

### The fix

I updated the existing code in editOnInput that reconciles more text nodes into one to a more robust solution that handles any number of nodes

All found text under the leaf node (the span with data-offset-key) is consolidated into a single data-text node, if no such node is present, it is created

DOM selection is updated when needed (typically is)

After the fix, the example at examples/draft-0-10-0/customStyles/customStyles.html doesn’t have this problem anymore.